### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ soundfile
 scikit-learn>=1.3.2
 funasr==1.0.28
 moviepy
-numpy
+numpy==1.26.4
 gradio
 modelscope
 torch>=1.13


### PR DESCRIPTION
A module that was compiled using NumPy 1.x cannot be run in NumPy 2.0.0 as it may crash. To support both 1.x and 2.x versions of NumPy, modules must be compiled with NumPy 2.0. Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to downgrade to 'numpy<2' or try to upgrade the affected module. We expect that some modules will need time to support NumPy 2.

https://github.com/modelscope/FunClip/issues/90

