### PR TITLE
bug fix

### DIFF
--- a/funclip/videoclipper.py
+++ b/funclip/videoclipper.py
@@ -25,6 +25,7 @@ class VideoClipper():
         logging.warning("Initializing VideoClipper.")
         self.funasr_model = funasr_model
         self.GLOBAL_COUNT = 0
+        self.lang = "zh"
 
     def recog(self, audio_input, sd_switch='no', state=None, hotwords="", output_dir=None):
         if state is None:
@@ -337,10 +338,16 @@ def get_parser():
         default=None,
         help="Output file path"
     )
+    parser.add_argument(
+        "--lang",
+        type=str,
+        default="zh",
+        help="Language choose"
+    )
     return parser
 
 
-def runner(stage, file, sd_switch, output_dir, dest_text, dest_spk, start_ost, end_ost, output_file, config=None):
+def runner(stage, file, sd_switch, output_dir, dest_text, dest_spk, start_ost, end_ost, output_file, lang="zh", config=None):
     audio_suffixs = ['.wav','.mp3','.aac','.m4a','.flac']
     video_suffixs = ['.mp4','.avi','.mkv','.flv','.mov','.webm','.ts','.mpeg']
     _,ext = os.path.splitext(file)
@@ -359,12 +366,20 @@ def runner(stage, file, sd_switch, output_dir, dest_text, dest_spk, start_ost, e
         from funasr import AutoModel
         # initialize funasr automodel
         logging.warning("Initializing modelscope asr pipeline.")
-        funasr_model = AutoModel(model="iic/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-                  vad_model="damo/speech_fsmn_vad_zh-cn-16k-common-pytorch",
-                  punc_model="damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
-                  spk_model="damo/speech_campplus_sv_zh-cn_16k-common",
-                  )
+        if lang == "zh":
+            funasr_model = AutoModel(model="iic/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+                    vad_model="damo/speech_fsmn_vad_zh-cn-16k-common-pytorch",
+                    punc_model="damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
+                    spk_model="damo/speech_campplus_sv_zh-cn_16k-common",
+                    )
+        elif lang == "en":
+            funasr_model = AutoModel(model="iic/speech_paraformer_asr-en-16k-vocab4199-pytorch",
+                    vad_model="damo/speech_fsmn_vad_zh-cn-16k-common-pytorch",
+                    punc_model="damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
+                    spk_model="damo/speech_campplus_sv_zh-cn_16k-common",
+                    )
         audio_clipper = VideoClipper(funasr_model)
+        audio_clipper.lang = lang
         if mode == 'audio':
             logging.warning("Recognizing audio file: {}".format(file))
             wav, sr = librosa.load(file, sr=16000)

--- a/funclip/videoclipper.py
+++ b/funclip/videoclipper.py
@@ -342,7 +342,7 @@ def get_parser():
         "--lang",
         type=str,
         default="zh",
-        help="Language choose"
+        help="Language choice"
     )
     return parser
 


### PR DESCRIPTION
Fix the bug in command line mode: AttributeError: 'VideoClipper' object has no attribute 'lang'
This bug was proposed in the issue of base repository.
The 'lang' attribute was added as a instance attribute of **audio_clipper** in **FunClip/funclip/launch.py**, but not a class attribute of **VideoClipper**, which further results in the missing attribute error when running in command line mode.