### PR TITLE
Fix error when no audio information is found.

### DIFF
--- a/funclip/videoclipper.py
+++ b/funclip/videoclipper.py
@@ -152,6 +152,11 @@ class VideoClipper():
             base_name, _ = os.path.splitext(video_filename)
             clip_video_file = base_name + '_clip.mp4'
             audio_file = base_name + '.wav'
+
+        if video.audio is None:
+            logging.error("No audio information found.")
+            sys.exit(1)
+
         video.audio.write_audiofile(audio_file)
         wav = librosa.load(audio_file, sr=16000)[0]
         # delete the audio file after processing


### PR DESCRIPTION
如果视频里没有音频，会出现异常：

```
Traceback (most recent call last):
  File "/home/lu4nx/FunClip/funclip/videoclipper.py", line 447, in <module>
    main()
  File "/home/lu4nx/FunClip/funclip/videoclipper.py", line 443, in main
    runner(**kwargs)
  File "/home/lu4nx/FunClip/funclip/videoclipper.py", line 396, in runner
    res_text, res_srt, state = audio_clipper.video_recog(file, sd_switch)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lu4nx/FunClip/funclip/videoclipper.py", line 155, in video_recog
    video.audio.write_audiofile(audio_file)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'write_audiofile'
```