### PR TITLE
Update requirements.txt and fix issue when rendering video with subtitles

### DIFF
--- a/funclip/videoclipper.py
+++ b/funclip/videoclipper.py
@@ -16,7 +16,7 @@ from moviepy.editor import *
 import moviepy.editor as mpy
 from moviepy.video.tools.subtitles import SubtitlesClip, TextClip
 from moviepy.editor import VideoFileClip, concatenate_videoclips
-from moviepy.video.compositing import CompositeVideoClip
+from moviepy.video.compositing.CompositeVideoClip import CompositeVideoClip
 from utils.subtitle_utils import generate_srt, generate_srt_clip
 from utils.argparse_tools import ArgumentParser, get_commandline_args
 from utils.trans_utils import pre_proc, proc, write_state, load_state, proc_spk, convert_pcm_to_float

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ librosa
 soundfile
 scikit-learn>=1.3.2
 funasr>=1.1.2
-moviepy
+moviepy==1.0.3
 numpy==1.26.4
 gradio
 modelscope


### PR DESCRIPTION
Update requirements.txt and fix issue when rendering video with subtitles

In moviepy version 1.0.3, CompositeVideoClip is a module within moviepy.video.compositing. To use it correctly, we need to import the CompositeVideoClip class from the module.

This commit makes the following changes:
- Update the import statement for CompositeVideoClip in videoclipper.py to import the class from the module.
- Fix the moviepy version to 1.0.3 in requirements.txt to avoid unexpected behavior due to version upgrades.

These changes resolve the issue encountered when rendering videos with subtitles using moviepy 1.0.3.