### PR TITLE
Feat/add litellm provider

### DIFF
--- a/funclip/launch.py
+++ b/funclip/launch.py
@@ -15,6 +15,7 @@ from videoclipper import VideoClipper
 from llm.openai_api import openai_call
 from llm.qwen_api import call_qwen_model
 from llm.g4f_openai_api import g4f_openai_call
+from llm.litellm_api import litellm_call
 from llm.twelvelabs_api import call_twelvelabs_pegasus
 from utils.trans_utils import extract_timestamps
 from introduction import top_md_1, top_md_3, top_md_4
@@ -165,7 +166,9 @@ if __name__ == "__main__":
             )
         
     def llm_inference(system_content, user_content, srt_text, model, apikey, video_input=None):
-        SUPPORT_LLM_PREFIX = ['qwen', 'gpt', 'g4f', 'moonshot', 'deepseek', 'pegasus']
+        SUPPORT_LLM_PREFIX = ['litellm', 'qwen', 'gpt', 'g4f', 'moonshot', 'deepseek', 'pegasus']
+        if model.startswith('litellm/'):
+            return litellm_call(apikey, model, user_content+'\n'+srt_text, system_content)
         if model.startswith('pegasus'):
             # TwelveLabs Pegasus reasons over the actual video (visuals + audio)
             # rather than the ASR transcript, so it needs the video source.
@@ -271,10 +274,12 @@ if __name__ == "__main__":
                                     choices=[
                                         "deepseek-chat",
                                         "qwen-plus",
-                                             "gpt-3.5-turbo", 
-                                             "gpt-3.5-turbo-0125", 
+                                             "gpt-3.5-turbo",
+                                             "gpt-3.5-turbo-0125",
                                              "gpt-4-turbo",
                                              "g4f-gpt-3.5-turbo",
+                                             "litellm/openai/gpt-4o",
+                                             "litellm/anthropic/claude-sonnet-4-6",
                                              "pegasus1.5"],
                                     value="deepseek-chat",
                                     label="LLM Model Name",

--- a/funclip/llm/litellm_api.py
+++ b/funclip/llm/litellm_api.py
@@ -1,16 +1,28 @@
 import logging
 
 
+def _import_litellm():
+    try:
+        import litellm
+        return litellm
+    except ImportError:
+        raise ImportError(
+            "litellm is required for the litellm provider. "
+            "Install it with: pip install 'litellm>=1.83.0'"
+        )
+
+
 def litellm_call(apikey,
                  model="openai/gpt-3.5-turbo",
                  user_content="How to make tomato beef stew?",
                  system_content=None):
-    import litellm
+    litellm = _import_litellm()
 
-    # Strip the "litellm/" prefix if present so the model name
-    # follows litellm's provider/model format (e.g. "anthropic/claude-sonnet-4-6")
     if model.startswith("litellm/"):
         model = model[len("litellm/"):]
+
+    if not model:
+        raise ValueError("Model name is empty after stripping litellm/ prefix")
 
     messages = []
     if system_content is not None and len(system_content.strip()):
@@ -26,6 +38,33 @@ def litellm_call(apikey,
     if apikey:
         kwargs['api_key'] = apikey
 
-    response = litellm.completion(**kwargs)
+    try:
+        response = litellm.completion(**kwargs)
+    except litellm.AuthenticationError as e:
+        logging.error(f"LiteLLM authentication failed: {e}")
+        raise
+    except litellm.NotFoundError as e:
+        logging.error(f"LiteLLM model not found: {e}")
+        raise
+    except litellm.RateLimitError as e:
+        logging.warning(f"LiteLLM rate limited: {e}")
+        raise
+    except litellm.Timeout as e:
+        logging.error(f"LiteLLM request timed out: {e}")
+        raise
+    except litellm.APIConnectionError as e:
+        logging.error(f"LiteLLM connection error: {e}")
+        raise
+
+    choices = getattr(response, 'choices', None)
+    if not choices:
+        logging.error("LiteLLM returned empty choices")
+        return ""
+
+    content = getattr(choices[0].message, 'content', None)
+    if content is None:
+        logging.warning("LiteLLM returned null content")
+        return ""
+
     logging.info("LiteLLM model inference done.")
-    return response.choices[0].message.content
+    return content

--- a/funclip/llm/litellm_api.py
+++ b/funclip/llm/litellm_api.py
@@ -1,0 +1,31 @@
+import logging
+
+
+def litellm_call(apikey,
+                 model="openai/gpt-3.5-turbo",
+                 user_content="How to make tomato beef stew?",
+                 system_content=None):
+    import litellm
+
+    # Strip the "litellm/" prefix if present so the model name
+    # follows litellm's provider/model format (e.g. "anthropic/claude-sonnet-4-6")
+    if model.startswith("litellm/"):
+        model = model[len("litellm/"):]
+
+    messages = []
+    if system_content is not None and len(system_content.strip()):
+        messages.append({'role': 'system', 'content': system_content})
+    messages.append({'role': 'user', 'content': user_content})
+
+    kwargs = {
+        'model': model,
+        'messages': messages,
+        'stream': False,
+        'drop_params': True,
+    }
+    if apikey:
+        kwargs['api_key'] = apikey
+
+    response = litellm.completion(**kwargs)
+    logging.info("LiteLLM model inference done.")
+    return response.choices[0].message.content

--- a/funclip/llm/litellm_api.py
+++ b/funclip/llm/litellm_api.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 
 def _import_litellm():
@@ -17,6 +18,7 @@ def litellm_call(apikey,
                  user_content="How to make tomato beef stew?",
                  system_content=None):
     litellm = _import_litellm()
+    api_base = os.environ.get("LITELLM_API_BASE", "").strip()
 
     if model.startswith("litellm/"):
         model = model[len("litellm/"):]
@@ -37,6 +39,8 @@ def litellm_call(apikey,
     }
     if apikey:
         kwargs['api_key'] = apikey
+    if api_base:
+        kwargs['api_base'] = api_base
 
     try:
         response = litellm.completion(**kwargs)

--- a/tests/test_litellm_api.py
+++ b/tests/test_litellm_api.py
@@ -1,0 +1,137 @@
+"""Tests for the LiteLLM provider module."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _mock_response(content="Test response"):
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = content
+    return resp
+
+
+def _empty_choices_response():
+    resp = MagicMock()
+    resp.choices = []
+    return resp
+
+
+def _null_content_response():
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = None
+    return resp
+
+
+class TestLiteLLMApi(unittest.TestCase):
+
+    def test_basic_call(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("Summary result")):
+            from funclip.llm.litellm_api import litellm_call
+            result = litellm_call("key", "litellm/openai/gpt-4o-mini", "article text", "Summarize")
+            self.assertEqual(result, "Summary result")
+            call_kwargs = litellm.completion.call_args[1]
+            self.assertEqual(call_kwargs["model"], "openai/gpt-4o-mini")
+
+    def test_prefix_stripped(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from funclip.llm.litellm_api import litellm_call
+            litellm_call("key", "litellm/anthropic/claude-sonnet-4-6", "text")
+            self.assertEqual(litellm.completion.call_args[1]["model"], "anthropic/claude-sonnet-4-6")
+
+    def test_no_prefix_passes_through(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from funclip.llm.litellm_api import litellm_call
+            litellm_call("key", "openai/gpt-4o", "text")
+            self.assertEqual(litellm.completion.call_args[1]["model"], "openai/gpt-4o")
+
+    def test_drop_params_true(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from funclip.llm.litellm_api import litellm_call
+            litellm_call("key", "openai/gpt-4o-mini", "text")
+            self.assertTrue(litellm.completion.call_args[1]["drop_params"])
+
+    def test_api_key_forwarded(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from funclip.llm.litellm_api import litellm_call
+            litellm_call("sk-test-123", "openai/gpt-4o-mini", "text")
+            self.assertEqual(litellm.completion.call_args[1]["api_key"], "sk-test-123")
+
+    def test_api_key_omitted_when_empty(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from funclip.llm.litellm_api import litellm_call
+            litellm_call("", "openai/gpt-4o-mini", "text")
+            self.assertNotIn("api_key", litellm.completion.call_args[1])
+
+    def test_system_content_included(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from funclip.llm.litellm_api import litellm_call
+            litellm_call("key", "openai/gpt-4o-mini", "user text", "system prompt")
+            messages = litellm.completion.call_args[1]["messages"]
+            self.assertEqual(len(messages), 2)
+            self.assertEqual(messages[0]["role"], "system")
+            self.assertEqual(messages[0]["content"], "system prompt")
+
+    def test_system_content_skipped_when_empty(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_mock_response("ok")):
+            from funclip.llm.litellm_api import litellm_call
+            litellm_call("key", "openai/gpt-4o-mini", "user text", "  ")
+            messages = litellm.completion.call_args[1]["messages"]
+            self.assertEqual(len(messages), 1)
+            self.assertEqual(messages[0]["role"], "user")
+
+    def test_empty_choices_returns_empty(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_empty_choices_response()):
+            from funclip.llm.litellm_api import litellm_call
+            result = litellm_call("key", "openai/gpt-4o-mini", "text")
+            self.assertEqual(result, "")
+
+    def test_null_content_returns_empty(self):
+        import litellm
+        with patch.object(litellm, "completion", return_value=_null_content_response()):
+            from funclip.llm.litellm_api import litellm_call
+            result = litellm_call("key", "openai/gpt-4o-mini", "text")
+            self.assertEqual(result, "")
+
+    def test_auth_error_raises(self):
+        import litellm
+        with patch.object(litellm, "completion",
+                          side_effect=litellm.AuthenticationError(message="Bad key", model="test", llm_provider="openai")):
+            from funclip.llm.litellm_api import litellm_call
+            with self.assertRaises(litellm.AuthenticationError):
+                litellm_call("bad-key", "openai/gpt-4o-mini", "text")
+
+    def test_rate_limit_raises(self):
+        import litellm
+        with patch.object(litellm, "completion",
+                          side_effect=litellm.RateLimitError(message="Rate limited", model="test", llm_provider="openai")):
+            from funclip.llm.litellm_api import litellm_call
+            with self.assertRaises(litellm.RateLimitError):
+                litellm_call("key", "openai/gpt-4o-mini", "text")
+
+    def test_timeout_raises(self):
+        import litellm
+        with patch.object(litellm, "completion",
+                          side_effect=litellm.Timeout(message="Timed out", model="test", llm_provider="openai")):
+            from funclip.llm.litellm_api import litellm_call
+            with self.assertRaises(litellm.Timeout):
+                litellm_call("key", "openai/gpt-4o-mini", "text")
+
+    def test_empty_model_after_strip_raises(self):
+        from funclip.llm.litellm_api import litellm_call
+        with self.assertRaises(ValueError):
+            litellm_call("key", "litellm/", "text")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Add **LiteLLM** as an LLM provider for the smart clipping feature, giving users access to 100+ LLM providers (Anthropic, Google, Azure, Bedrock, Groq, Ollama, and more) via the `litellm/` model prefix.

## Changes

- `funclip/llm/litellm_api.py` - New `litellm_call()` function following the same pattern as `openai_call()` and `call_qwen_model()`
- `funclip/launch.py` - Added `litellm/` prefix dispatch, added `litellm` to `SUPPORT_LLM_PREFIX`, added example LiteLLM models to the Gradio dropdown
- `tests/test_litellm_api.py` - 14 unit tests

## Implementation details

- Model names use `litellm/provider/model` format (e.g. `litellm/anthropic/claude-sonnet-4-6`). The `litellm/` prefix is stripped before calling `litellm.completion()`, so the underlying model string follows litellm's standard `provider/model` convention
- `drop_params=True` by default for cross-provider compatibility
- Self-hosted proxy support via `LITELLM_API_BASE` env var - users running their own LiteLLM gateway set the base URL and use whatever model names their proxy exposes
- Specific exception handling: `AuthenticationError`, `NotFoundError` propagate immediately; `RateLimitError`, `Timeout`, `APIConnectionError` propagate for caller handling
- Empty responses (null content, empty choices) return `""` gracefully
- Lazy import so the module loads without litellm installed

## Tests

**14 unit tests covering:**
- Basic call with prefix stripping (`litellm/anthropic/claude-sonnet-4-6` -> `anthropic/claude-sonnet-4-6`)
- No-prefix passthrough (`openai/gpt-4o` works as-is)
- `drop_params=True` always present
- API key forwarded when set, omitted when empty
- System content included when non-empty, skipped when blank
- Empty choices and null content return `""`
- Auth error, rate limit, timeout propagate correctly
- Empty model after prefix strip raises `ValueError`

**Live E2E (Anthropic via Azure Foundry):**
```
>>> litellm_call('', 'litellm/anthropic/claude-sonnet-4-6',
...     'Select 2 key timestamps from these subtitles:\n00:00:30 Today we make pasta\n00:02:00 Add the pasta\n00:04:00 Plate and serve',
...     'You are a video clipping assistant.')
'Here are the 2 most important timestamps from the cooking video...'
```

## Example usage

```python
# Direct SDK usage (no proxy, litellm routes to provider)
from funclip.llm.litellm_api import litellm_call

# Provider API key read from env (e.g. ANTHROPIC_API_KEY)
result = litellm_call(
    apikey="",
    model="litellm/anthropic/claude-sonnet-4-6",
    user_content="Subtitles:\n00:01:00 Introduction\n00:05:00 Main topic\n00:10:00 Conclusion",
    system_content="Select the 3 most important timestamps for clipping."
)
print(result)
```

```bash
# With a self-hosted LiteLLM proxy
export LITELLM_API_BASE=http://my-gateway:4000
# Model name matches what the proxy config exposes
# In Gradio UI: type "litellm/my-claude" in the model dropdown
```

In the Gradio UI, select or type a model name with the `litellm/` prefix. `allow_custom_value=True` on the dropdown lets users type any model name.

## Risk / Compatibility

- Additive only - existing OpenAI, Qwen, g4f, Pegasus providers untouched
- Users who don't use the `litellm/` prefix see zero behavior change
- `litellm` imported lazily, module loads without it installed
