### PR TITLE
docs: require issue resolution evidence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,15 @@ For broad ASR, deployment, or model-selection questions, the FunASR docs and dis
 - https://modelscope.github.io/FunASR/
 - https://github.com/modelscope/FunASR/discussions
 
+## Resolving issues
+
+A merged pull request, a green `main` branch, or an available release does not by itself prove that a reported problem is resolved. Keep user-reported issues open until either:
+
+- the reporter confirms the fix on the affected workflow; or
+- a maintainer reproduces the original failure, verifies the fix in a publicly available version, records the evidence in the issue, and allows a reasonable feedback window.
+
+When a fix needs a release, link the released version and ask the reporter to retest before closing. Use a waiting-for-feedback label when available instead of treating silence as confirmation.
+
 ## Local setup
 
 ```bash


### PR DESCRIPTION
## Summary
- document that a merged PR, green main branch, or available release is not sufficient evidence to close a user-reported issue
- require reporter confirmation or maintainer reproduction plus released-version verification and a reasonable feedback window
- ask maintainers to link the release and keep the issue in a waiting-for-feedback state instead of treating silence as confirmation

## Validation
- git diff --check
- verified this PR changes only CONTRIBUTING.md
- verified the resolution section contains the reporter-confirmation, released-version, evidence, and feedback-window requirements

Signed commit with DCO.