### PR TITLE
docs: clarify MOSS speaker-label boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 <a name="What's New"></a>
 ## What's New🚀
-- 2026/08/30 FunClip adds the third-party [OpenMOSS/MOSS-Transcribe-Diarize](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize) model as an opt-in `moss` path. It provides long-form ASR, speaker identity, and segment timestamps without external `vad_model` or `spk_model`, through FunASR's vLLM adapter. OpenMOSS owns and maintains the model; FunClip only integrates its published contract.
+- 2026/08/30 FunClip adds the third-party [OpenMOSS/MOSS-Transcribe-Diarize](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize) model as an opt-in `moss` path. It provides long-form ASR, anonymous speaker labels, and segment timestamps without external `vad_model` or `spk_model`, through FunASR's vLLM adapter. OpenMOSS owns and maintains the model; FunClip only integrates its published contract.
 - 2026/08/03 [FunClip v2.1.1](https://github.com/modelscope/FunClip/releases/tag/v2.1.1) fixes fresh Gradio 4 installations by constraining the incompatible Starlette 1.x runtime, keeps `--listen` container startup private unless `--share` is explicitly requested, makes transcript matching case-insensitive, and adds MiniMax M2.7 provider routes.
 - 2026/07/24 [FunClip v2.1.0](https://github.com/modelscope/FunClip/releases/tag/v2.1.0) is the first versioned GitHub release. It packages the current Fun-ASR-Nano, SenseVoice, Paraformer, and LLM-assisted clipping application as checksum-protected source archives for a stable rollback point.
 - 2026/05/20 FunClip now supports [Fun-ASR-Nano](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) and [SenseVoice](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) models. The `fun-asr-nano` option loads the flagship Fun-ASR-Nano-2512 checkpoint for Mandarin, English, Japanese, 7 Chinese dialect groups, and 26 regional accents; it does not load the separate 31-language Fun-ASR-MLT-Nano-2512 checkpoint. SenseVoice adds emotion recognition and audio event detection. Run `python funclip/launch.py -m fun-asr-nano` or `-m sensevoice` to try. For precise text-based clipping, use Paraformer because the released Nano checkpoint does not provide reliable character-level timestamps.
@@ -120,7 +120,7 @@ python funclip/launch.py
 # '-m fun-asr-nano' for the flagship Fun-ASR-Nano model (Mandarin, English,
 # Japanese, 7 Chinese dialect groups, and 26 regional accents)
 # '-m sensevoice' for SenseVoice model (multilingual ASR + emotion + audio event detection)
-# '--model moss' for OpenMOSS long-form ASR + speaker identity + timestamps
+# '--model moss' for OpenMOSS long-form ASR + anonymous speaker labels + timestamps
 # '-l en' for English audio recognize
 # '-p xxx' for setting port number
 # '-s True' for establishing service for public accessing
@@ -148,7 +148,7 @@ python funclip/launch.py --model moss --moss-backend vllm
 MOSS_API_KEY=replace-me python funclip/launch.py --model moss
 ```
 
-MOSS performs segmentation and speaker diarization end to end. Do not attach an external `vad_model` or `spk_model`, because chunking would break global speaker identity. Its timestamps are segment-level: SRT, speaker clipping (`spkS01`, `spkS02`, ...), and LLM timestamp clipping are supported, while precise arbitrary text clipping still requires Paraformer's token timestamps. FunClip currently exposes the vLLM path because it is compatible with the standard Transformers 4.x environment and has an end-to-end tested OpenAI transcription contract.
+MOSS performs segmentation and speaker diarization end to end. Its `spkS01`, `spkS02`, ... values are anonymous speaker labels within the current recording; the model does not identify a known person, verify an enrolled voiceprint, or guarantee label continuity across separate recordings. Do not attach an external `vad_model` or `spk_model`, because chunking would break consistent speaker assignment within the recording. Its timestamps are segment-level: SRT, speaker clipping, and LLM timestamp clipping are supported, while precise arbitrary text clipping still requires Paraformer's token timestamps. FunClip currently exposes the vLLM path because it is compatible with the standard Transformers 4.x environment and has an end-to-end tested OpenAI transcription contract.
 
 If you only need offline speech transcription on CPU or edge devices and do not need FunClip's video clipping UI, use the FunASR llama.cpp / GGUF runtime instead: [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · [Fun-ASR-Nano-GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [SenseVoiceSmall-GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF).
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -36,7 +36,7 @@
 <a name="近期更新"></a>
 ## 近期更新🚀
 
-- 2026/08/30 FunClip 新增第三方 [OpenMOSS/MOSS-Transcribe-Diarize](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize) 可选路径。它通过 FunASR 的 vLLM 适配器提供长音频 ASR、说话人身份和分段时间戳，不需要外部 `vad_model` 或 `spk_model`。模型归 OpenMOSS 所有并由其维护，FunClip 只集成公开接口。
+- 2026/08/30 FunClip 新增第三方 [OpenMOSS/MOSS-Transcribe-Diarize](https://github.com/OpenMOSS/MOSS-Transcribe-Diarize) 可选路径。它通过 FunASR 的 vLLM 适配器提供长音频 ASR、匿名说话人标签和分段时间戳，不需要外部 `vad_model` 或 `spk_model`。模型归 OpenMOSS 所有并由其维护，FunClip 只集成公开接口。
 - 2026/08/03 [FunClip v2.1.1](https://github.com/modelscope/FunClip/releases/tag/v2.1.1) 修复 Gradio 4 新安装环境与 Starlette 1.x 的不兼容问题；容器使用 `--listen` 时不会自动创建公网分享链接；文本匹配改为大小写不敏感，并新增 MiniMax M2.7 模型路由。
 - 2026/07/24 [FunClip v2.1.0](https://github.com/modelscope/FunClip/releases/tag/v2.1.0) 是首个带版本号的 GitHub Release，将当前支持 Fun-ASR-Nano、SenseVoice、Paraformer 与大模型智能剪辑的应用打包为带 SHA-256 校验的源码归档，提供稳定的下载与回退节点。
 - 2026/05/20 FunClip 现在支持 [Fun-ASR-Nano](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512) 与 [SenseVoice](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) 模型。`fun-asr-nano` 选项加载旗舰版 Fun-ASR-Nano-2512，支持普通话、英语、日语、7 类中文方言和 26 种地域口音；该选项不会加载独立的 31 语种 Fun-ASR-MLT-Nano-2512。SenseVoice 支持多语种识别，并额外输出情绪识别与音频事件检测标签。可通过 `python funclip/launch.py -m fun-asr-nano` 或 `python funclip/launch.py -m sensevoice` 启动体验。需要精确按文本裁剪时请使用 Paraformer，因为当前发布的 Nano checkpoint 不提供可靠的字符级时间戳。
@@ -120,7 +120,7 @@ python funclip/launch.py
 # '-m fun-asr-nano' 使用旗舰版 Fun-ASR-Nano（普通话、英语、日语、
 # 7 类中文方言和 26 种地域口音）
 # '-m sensevoice' 使用 SenseVoice 模型（多语种 ASR + 情绪识别 + 音频事件检测）
-# '--model moss' 使用 OpenMOSS 长音频 ASR + 说话人身份 + 时间戳
+# '--model moss' 使用 OpenMOSS 长音频 ASR + 匿名说话人标签 + 时间戳
 # '-l en' for English audio recognize
 # '-p xxx' for setting port number
 # '-s True' for establishing service for public accessing
@@ -147,7 +147,7 @@ python funclip/launch.py --model moss --moss-backend vllm
 MOSS_API_KEY=replace-me python funclip/launch.py --model moss
 ```
 
-MOSS 端到端完成分段与说话人识别，不要再配置外部 `vad_model` 或 `spk_model`，否则切块会破坏全局说话人身份。它提供段级时间戳，适合生成 SRT、按说话人（`spkS01`、`spkS02` 等）剪辑以及 LLM 按时间剪辑；任意文本的精确剪辑仍应使用带 token 时间戳的 Paraformer。FunClip 当前只开放 vLLM 路径，因为它兼容标准 Transformers 4.x 环境，并且已经通过 OpenAI 转写接口的端到端测试。
+MOSS 端到端完成分段与说话人分离。`spkS01`、`spkS02` 等值只是当前录音内的匿名说话人标签，不能识别已知人物、验证已注册声纹，也不保证跨录音保持同一标签。不要再配置外部 `vad_model` 或 `spk_model`，否则切块会破坏单次录音内的标签一致性。它提供段级时间戳，适合生成 SRT、按说话人剪辑以及 LLM 按时间剪辑；任意文本的精确剪辑仍应使用带 token 时间戳的 Paraformer。FunClip 当前只开放 vLLM 路径，因为它兼容标准 Transformers 4.x 环境，并且已经通过 OpenAI 转写接口的端到端测试。
 
 如果你只需要在 CPU 或边缘设备上离线转写语音，而不需要 FunClip 的视频剪辑界面，请优先使用 FunASR llama.cpp / GGUF 运行时：[funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · [Fun-ASR-Nano-GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [SenseVoiceSmall-GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF)。
 

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -46,6 +46,25 @@ def test_readmes_document_moss_ownership_backends_and_timestamp_boundary():
         assert "--moss-backend hf" not in text
 
 
+def test_readmes_describe_moss_speakers_as_anonymous_labels():
+    combined = "\n".join(
+        (ROOT / readme).read_text() for readme in ["README.md", "README_zh.md"]
+    )
+
+    for misleading_claim in (
+        "speaker identity",
+        "speaker identities",
+        "说话人身份",
+        "身份识别",
+    ):
+        assert misleading_claim not in combined
+
+    assert "anonymous speaker labels" in combined
+    assert "匿名说话人标签" in combined
+    assert "does not identify a known person" in combined
+    assert "不能识别已知人物" in combined
+
+
 def test_readmes_route_edge_asr_users_to_gguf_runtime():
     required_links = [
         "https://www.funasr.com/llama-cpp.html",


### PR DESCRIPTION
## Summary

- describe spkS01 / spkS02 as anonymous labels within the current recording
- clarify that MOSS diarization does not identify known people or verify enrolled voiceprints
- retain third-party OpenMOSS attribution, vLLM serving, segment timestamp, and no-external-VAD boundaries
- add a bilingual README regression contract

## Verification

- red phase: the new boundary test failed against exact base 3691a4d28e925268b3201c34f00036362d48aa07
- 6 passed in tests/test_funasr_requirement.py
- git diff --check passed

Exact signed+DCO head: aa89e16177e57db77c05a9e0ddad49b9a46e1adc.

This PR does not close a user issue.